### PR TITLE
feat: #2 axiosInstance 초기화 & suggestion get API 함수 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^16.18.47",
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
+        "axios": "^1.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.15.0",
@@ -5221,6 +5222,29 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14897,6 +14921,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.18.47",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
+    "axios": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.15.0",

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,7 @@
+import { suggestionAPI } from './suggestion'
+
+const API = {
+  suggestion: suggestionAPI,
+}
+
+export { API }

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -5,18 +5,13 @@ const BASE_URL = 'https://json-server-6gjfchfpb-wanted-team7.vercel.app/'
 const axiosInstance = axios.create({ baseURL: BASE_URL })
 
 axiosInstance.interceptors.request.use((config) => {
-  /** @description API 호출될 때마다 console.info 출력*/
   console.info('calling api')
   return config
 })
 
 axiosInstance.interceptors.response.use(
-  (response) => {
-    /** @description 200대 응답이라면 이 콜백이 실행됨*/
-    return response
-  },
+  (response) => response,
   (error) => {
-    /** @description 200대 응답이 아니라면 이 콜백이 실행됨*/
     console.error(error)
     return Promise.reject(error)
   }

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,0 +1,37 @@
+import axios from 'axios'
+
+const BASE_URL = 'https://json-server-6gjfchfpb-wanted-team7.vercel.app/'
+
+const axiosInstance = axios.create({ baseURL: BASE_URL })
+
+axiosInstance.interceptors.request.use((config) => {
+  /** @description API 호출될 때마다 console.info 출력*/
+  console.info('API CALL to ', config.url, config.params)
+  return config
+})
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    /** @description 200대 응답이라면 이 콜백이 실행됨*/
+    return response
+  },
+  (error) => {
+    /** @description 200대 응답이 아니라면 이 콜백이 실행됨*/
+    console.error(error)
+    return Promise.reject(error)
+  }
+)
+
+export interface QueryParam {
+  [key: string]: string
+  q: string
+}
+
+const instance = {
+  get: <T>(url: string, param: QueryParam) =>
+    axiosInstance.get<T>(url, {
+      params: param,
+    }),
+}
+
+export { instance }

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -6,7 +6,7 @@ const axiosInstance = axios.create({ baseURL: BASE_URL })
 
 axiosInstance.interceptors.request.use((config) => {
   /** @description API 호출될 때마다 console.info 출력*/
-  console.info('API CALL to ', config.url, config.params)
+  console.info('calling api')
   return config
 })
 

--- a/src/apis/suggestion.ts
+++ b/src/apis/suggestion.ts
@@ -1,0 +1,14 @@
+import { instance } from './instance'
+
+type SickObj = {
+  sickCd: string
+  sickNm: string
+}
+
+export type GetSuggestionResponse = SickObj[]
+
+const getSuggestion = (searchTerm: string) => {
+  return instance.get<GetSuggestionResponse>('sick', { q: searchTerm })
+}
+
+export const suggestionAPI = { get: getSuggestion }


### PR DESCRIPTION
# Description
## JSON-Server API 배포 안내
`https://json-server-6gjfchfpb-wanted-team7.vercel.app/`로 `JSON-Server`를 배포하였습니다. 
팀 계정은 14일 pro-trial이라서, 이후에는 개인 레포로 옮겨서 다시 배포를 해야겠네요.

관련 코드는 [팀 레포-json-server](https://github.com/wanted-pre-onboarding-team-12th-7/json-server)에 있습니다.

핵심 기능인 쿼리문의 동작이 제대로 동작하는 것을 확인했습니다. 

혹여나 이상이 발생하면 말씀해주세요. 

개인 프로젝트 마무리짓고 서버 레포의 불필요한 로직들을 정리하겠습니다.

## Axios Instance 추가 및 API함수 사용안내
- 이번 프로젝트에서 API함수 호출시에는 `API.suggestion.get(검색어:string)`로 호출하면 되겠습니다.

## 요구사항이었던 API 함수 호출 시 로그 출력
- axios interceptor 를 통해서 요청이 발동하면 `console.info`를 출력하도록 처리했습니다. 
  - 문구는 요구사항에 적혀있는 대로 `console.info('calling api')`로 수정했습니다. 
- 따라서 `API.suggestion.get`을 컴포넌트에서 사용하실 때는 콘솔문을 별도로 작성하시지 않아도 됩니다.

