### PR TITLE
feat: #11 API 호출별 로컬 캐싱 구현

### DIFF
--- a/src/hooks/useSuggestions.ts
+++ b/src/hooks/useSuggestions.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 
 import { SickObj, suggestionAPI } from '../apis/suggestion'
+import { CacheRepository } from '../store/CacheRepository'
+
+const cacheRepository = new CacheRepository<SickObj>()
 
 const useSuggestions = (keyword: string) => {
   const [suggestions, setSuggestions] = useState<SickObj[]>([])
@@ -11,15 +14,23 @@ const useSuggestions = (keyword: string) => {
     if (keyword !== '') {
       setLoading(true)
 
-      suggestionAPI
-        .get(keyword)
-        .then((res) => {
-          setSuggestions(res.data)
-        })
-        .catch(() => setError(true))
-        .finally(() => {
-          setLoading(false)
-        })
+      const cache = cacheRepository.get(keyword)
+
+      if (cache && cache.expireTime > Date.now()) {
+        setSuggestions(cache.data)
+        setLoading(false)
+      } else {
+        suggestionAPI
+          .get(keyword)
+          .then((res) => {
+            setSuggestions(res.data)
+            cacheRepository.set(keyword, res.data)
+          })
+          .catch(() => setError(true))
+          .finally(() => {
+            setLoading(false)
+          })
+      }
     } else {
       setSuggestions([])
     }

--- a/src/store/CacheRepository.ts
+++ b/src/store/CacheRepository.ts
@@ -1,0 +1,22 @@
+interface LocalCache<T> {
+  data: T[]
+  expireTime: number
+}
+
+const MINUTES_IN_MILLISECONDS = 60000
+const EXPIRE_TIME = MINUTES_IN_MILLISECONDS * 1
+
+export class CacheRepository<T> {
+  #cache: Record<string, LocalCache<T>> = {}
+
+  set(key: string, value: T[]) {
+    this.#cache[key] = {
+      data: value,
+      expireTime: Date.now() + EXPIRE_TIME,
+    }
+  }
+
+  get(key: string) {
+    return this.#cache[key]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Description

로컬 캐시기능을 구현하였습니다.

## Changes

- [private class field](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Classes/Private_class_fields) 사용을 위해 compilerOptions의 target을 es6로 변경하였습니다.

```js
// tsconfig.json

{
  "compilerOptions": {
    "target": "es6",
    ...
  },
  ...
}
```

- 메모리에 API의 결과값을 저장할 수 있는 `CacheRepository`를 구현하였습니다.
- 다양한 타입에 대응할 수 있도록 제네릭으로 구현하였습니다.

```js
// src/store/CacheRepository.ts

interface LocalCache<T> {
  data: T[]
  expireTime: number
}

const MINUTES_IN_MILLISECONDS = 60000
const EXPIRE_TIME = MINUTES_IN_MILLISECONDS * 1

export class CacheRepository<T> {
  #cache: Record<string, LocalCache<T>> = {}

  set(key: string, value: T[]) {
    this.#cache[key] = {
      data: value,
      expireTime: Date.now() + EXPIRE_TIME,
    }
  }

  get(key: string) {
    return this.#cache[key]
  }
}
```

- useSuggestions 커스텀 훅에 캐시기능을 연동하였습니다.
- 해당 검색어에 대한 캐시가 존재하고, expireTime이 지나지 않았으면 캐시에 저장된 값으로 suggestions의 상태를 업데이트합니다.
- 해당 검색어에 대한 캐시가 존재하지 않거나, expireTime이 지났으면, API 응답 값으로 suggestions의 상태를 업데이트하고 캐시에 결과값을 저장합니다.

```js
// src/hooks/useSuggestions.ts

useEffect(() => {
  if (keyword !== '') {
    setLoading(true)

    const cache = cacheRepository.get(keyword)

    if (cache && cache.expireTime > Date.now()) {
      setSuggestions(cache.data)
      setLoading(false)
    } else {
      suggestionAPI
        .get(keyword)
        .then((res) => {
          setSuggestions(res.data)
          cacheRepository.set(keyword, res.data)
        })
        .catch(() => setError(true))
        .finally(() => {
          setLoading(false)
        })
    }
  } else {
    setSuggestions([])
  }
}, [keyword])
```

## Preview

> (다음 동영상은 expireTime을 10초로 설정한 상태입니다.)

https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-3-7/assets/93248349/cec1ec22-1133-44b0-b777-03f2dc7bdccb
