### PR TITLE
refactor: #14 캐싱 관심사 분리

### DIFF
--- a/src/hooks/useSuggestions.ts
+++ b/src/hooks/useSuggestions.ts
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react'
 
 import { SickObj, suggestionAPI } from '../apis/suggestion'
-import { CacheRepository } from '../store/CacheRepository'
-
-const cacheRepository = new CacheRepository<SickObj>()
 
 const useSuggestions = (keyword: string) => {
   const [suggestions, setSuggestions] = useState<SickObj[]>([])
@@ -13,24 +10,15 @@ const useSuggestions = (keyword: string) => {
   useEffect(() => {
     if (keyword !== '') {
       setLoading(true)
-
-      const cache = cacheRepository.get(keyword)
-
-      if (cache && cache.expireTime > Date.now()) {
-        setSuggestions(cache.data)
-        setLoading(false)
-      } else {
-        suggestionAPI
-          .get(keyword)
-          .then((res) => {
-            setSuggestions(res.data)
-            cacheRepository.set(keyword, res.data)
-          })
-          .catch(() => setError(true))
-          .finally(() => {
-            setLoading(false)
-          })
-      }
+      suggestionAPI
+        .get(keyword)
+        .then((data) => {
+          setSuggestions(data)
+        })
+        .catch(() => setError(true))
+        .finally(() => {
+          setLoading(false)
+        })
     } else {
       setSuggestions([])
     }


### PR DESCRIPTION
## Description

#14 참조

## Changes

- [useSuggestions](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-3-7/blob/main/src/hooks/useSuggestions.ts) 커스텀 훅으로부터 캐싱로직을 분리하였습니다.

```js
// before

useEffect(() => {
  if (keyword !== '') {
    setLoading(true)

    const cache = cacheRepository.get(keyword)

    if (cache && cache.expireTime > Date.now()) {
      setSuggestions(cache.data)
      setLoading(false)
    } else {
      suggestionAPI
        .get(keyword)
        .then((res) => {
          setSuggestions(res.data)
          cacheRepository.set(keyword, res.data)
        })
        .catch(() => setError(true))
        .finally(() => {
          setLoading(false)
        })
    }
  } else {
    setSuggestions([])
  }
}, [keyword])
```

```js
// after

useEffect(() => {
  if (keyword !== '') {
    setLoading(true)
    suggestionAPI
      .get(keyword)
      .then((data) => {
        setSuggestions(data)
      })
      .catch(() => setError(true))
      .finally(() => {
        setLoading(false)
      })
  } else {
    setSuggestions([])
  }
}, [keyword])
```

- [getSuggestion](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-3-7/blob/main/src/apis/suggestion.ts) API 에서 다음과 같이 캐싱 로직을 처리합니다.

```js
const cacheRepository = new CacheRepository<SickObj>()

const getSuggestion = async (searchTerm: string) => {
  const cache = cacheRepository.get(searchTerm)

  if (cache && cache.expireTime > Date.now()) {
    return cache.data
  } else {
    const { data } = await instance.get<GetSuggestionResponse>('sick', { q: searchTerm })
    cacheRepository.set(searchTerm, data)

    return data
  }
}
```

## Preview

#12 와 동일합니다.