### PR TITLE
feat: #13 키보드로 검색결과 이동

### DIFF
--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -1,9 +1,15 @@
 import { SearchFormProps } from './type'
 
-function SearchForm({ getInput, keyword }: SearchFormProps) {
+function SearchForm({ getInput, keyword, openSuggestion, navigateFocus }: SearchFormProps) {
   return (
-    <form>
-      <input type="text" value={keyword} onChange={(e) => getInput(e.target.value)} />
+    <form onSubmit={(e) => e.preventDefault()}>
+      <input
+        type="text"
+        value={keyword}
+        onChange={(e) => getInput(e.target.value)}
+        onFocus={openSuggestion}
+        onKeyDown={navigateFocus}
+      />
       <button type="button">검색하기</button>
     </form>
   )

--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -1,14 +1,14 @@
 import { SearchFormProps } from './type'
 
-function SearchForm({ getInput, keyword, openSuggestion, navigateFocus }: SearchFormProps) {
+function SearchForm({ getInput, keyword, changeIndexByKeyDown }: SearchFormProps) {
   return (
     <form onSubmit={(e) => e.preventDefault()}>
       <input
         type="text"
         value={keyword}
+        onBlur={() => changeIndexByKeyDown.setIndex(-1)}
         onChange={(e) => getInput(e.target.value)}
-        onFocus={openSuggestion}
-        onKeyDown={navigateFocus}
+        onFocus={() => changeIndexByKeyDown.setIndex(0)}
       />
       <button type="button">검색하기</button>
     </form>

--- a/src/components/search/SearchSuggestion.tsx
+++ b/src/components/search/SearchSuggestion.tsx
@@ -1,14 +1,15 @@
+import { styled } from 'styled-components'
+
 import { SearchSuggestionProps } from './type'
 import { SickObj } from '../../apis/suggestion'
-import useDebounce from '../../hooks/useDebounce'
-import useSuggestions from '../../hooks/useSuggestions'
 
-const DEBOUNCE_DELAY = 500
-
-function SearchSuggestion({ keyword }: SearchSuggestionProps) {
-  const debouncedValue = useDebounce(keyword, DEBOUNCE_DELAY)
-  const { suggestions, loading, error } = useSuggestions(debouncedValue)
-
+function SearchSuggestion({
+  keyword,
+  selectIndex,
+  suggestions,
+  loading,
+  error,
+}: SearchSuggestionProps) {
   return (
     <>
       {loading ? (
@@ -25,10 +26,16 @@ function SearchSuggestion({ keyword }: SearchSuggestionProps) {
               <div>추천 검색어가 없습니다.</div>
             ) : (
               <ul>
-                {suggestions.map((suggestion: SickObj) => {
+                {suggestions.map((suggestion: SickObj, index) => {
                   return (
                     <li key={suggestion.sickCd}>
-                      <button type="button">{suggestion.sickNm}</button>
+                      <button
+                        // FIXME: select 테스트를 위한 스타일입니다. 스타일 작업시 제거해주세요.
+                        style={selectIndex === index ? { background: 'red' } : {}}
+                        type="button"
+                      >
+                        {suggestion.sickNm}
+                      </button>
                     </li>
                   )
                 })}

--- a/src/components/search/SearchSuggestion.tsx
+++ b/src/components/search/SearchSuggestion.tsx
@@ -1,5 +1,3 @@
-import { styled } from 'styled-components'
-
 import { SearchSuggestionProps } from './type'
 import { SickObj } from '../../apis/suggestion'
 

--- a/src/components/search/type.ts
+++ b/src/components/search/type.ts
@@ -1,8 +1,16 @@
+import { SickObj } from '../../apis/suggestion'
+
 export interface SearchSuggestionProps {
   keyword: string
+  selectIndex: number
+  suggestions: SickObj[]
+  loading: boolean
+  error: boolean
 }
 
 export interface SearchFormProps {
   getInput: (vlaue: string) => void
   keyword: string
+  openSuggestion: () => void
+  navigateFocus: (e: React.KeyboardEvent) => void
 }

--- a/src/components/search/type.ts
+++ b/src/components/search/type.ts
@@ -11,6 +11,8 @@ export interface SearchSuggestionProps {
 export interface SearchFormProps {
   getInput: (vlaue: string) => void
   keyword: string
-  openSuggestion: () => void
-  navigateFocus: (e: React.KeyboardEvent) => void
+  changeIndexByKeyDown: {
+    (e: React.KeyboardEvent): void
+    setIndex(idx: number): void
+  }
 }

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -1,79 +1,46 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
-const useKeyboardNavigation = <T>(
-  resultArray: T[],
-  isResultOpen: boolean,
-  setIsResultOpen: React.Dispatch<React.SetStateAction<boolean>>
-) => {
-  const [selectIndex, setSelectIndex] = useState(-1)
-  const [selectedItem, setSelectedItem] = useState<T | null>(null)
+const useKeyboardNavigation = <T>(dataArr: T[]) => {
+  const [currentIndex, setCurrentIndex] = useState(-1)
 
-  const startIndex = 0
-  const endIndex = resultArray.length - 1
-  const isStartIndex = selectIndex === startIndex
-  const isEndIndex = selectIndex === endIndex
-
-  const openResult = () => {
-    setIsResultOpen(true)
-  }
-
-  const closeResult = () => {
-    setIsResultOpen(false)
-  }
+  const endIndex = dataArr.length - 1
+  const isEndIndex = currentIndex === endIndex
 
   const moveToPrev = (e: React.KeyboardEvent) => {
-    e.preventDefault()
-    if (isStartIndex) {
-      closeResult()
-    } else {
-      setSelectIndex((prev) => prev - 1)
+    if (currentIndex >= 0) {
+      e.preventDefault()
     }
+    setCurrentIndex((prev) => Math.max(prev - 1, -1))
   }
 
   const moveToNext = (e: React.KeyboardEvent) => {
-    if (isResultOpen) {
-      setSelectIndex((prev) => (prev < endIndex ? prev + 1 : prev))
-      if (e.key === 'Tab') {
-        if (isEndIndex) {
-          closeResult()
-        } else {
-          e.preventDefault()
-        }
-      }
-    }
-    if (!isResultOpen && e.key === 'ArrowDown') {
-      setSelectIndex(0)
-      openResult()
+    if (e.key === 'Tab' && isEndIndex) {
+      closeAndReset()
+    } else {
+      e.preventDefault()
+      setCurrentIndex((prev) => Math.min(prev + 1, endIndex))
     }
   }
 
   const closeAndReset = () => {
-    closeResult()
-    setSelectIndex(-1)
+    setCurrentIndex(-1)
   }
 
-  const selectCurrent = () => {
-    setSelectedItem(resultArray[selectIndex])
-  }
-
-  const navigateFocus = (e: React.KeyboardEvent) => {
+  const changeIndexByKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'ArrowUp' || (e.shiftKey && e.key === 'Tab')) {
       moveToPrev(e)
     } else if (e.key === 'ArrowDown' || e.key === 'Tab') {
       moveToNext(e)
     } else if (e.key === 'Escape') {
       closeAndReset()
-    } else if (e.key === 'Enter') {
-      selectCurrent()
     }
   }
 
-  useEffect(() => {
-    openResult()
-    setSelectIndex(-1)
-  }, [resultArray])
+  changeIndexByKeyDown.setIndex = (idx: number) => {
+    setCurrentIndex(idx)
+  }
 
-  return { selectIndex, navigateFocus, selectedItem }
+  return { currentIndex, changeIndexByKeyDown }
 }
 
 export default useKeyboardNavigation

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 const useKeyboardNavigation = <T>(dataArr: T[]) => {
   const [currentIndex, setCurrentIndex] = useState(-1)
@@ -39,6 +39,10 @@ const useKeyboardNavigation = <T>(dataArr: T[]) => {
   changeIndexByKeyDown.setIndex = (idx: number) => {
     setCurrentIndex(idx)
   }
+
+  useEffect(() => {
+    changeIndexByKeyDown.setIndex(0)
+  }, [dataArr])
 
   return { currentIndex, changeIndexByKeyDown }
 }

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+
+const useKeyboardNavigation = <T>(
+  resultArray: T[],
+  isResultOpen: boolean,
+  setIsResultOpen: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+  const [selectIndex, setSelectIndex] = useState(-1)
+  const [selectedItem, setSelectedItem] = useState<T | null>(null)
+
+  const startIndex = 0
+  const endIndex = resultArray.length - 1
+  const isStartIndex = selectIndex === startIndex
+  const isEndIndex = selectIndex === endIndex
+
+  const openResult = () => {
+    setIsResultOpen(true)
+  }
+
+  const closeResult = () => {
+    setIsResultOpen(false)
+  }
+
+  const moveToPrev = (e: React.KeyboardEvent) => {
+    e.preventDefault()
+    if (isStartIndex) {
+      closeResult()
+    } else {
+      setSelectIndex((prev) => prev - 1)
+    }
+  }
+
+  const moveToNext = (e: React.KeyboardEvent) => {
+    if (isResultOpen) {
+      setSelectIndex((prev) => (prev < endIndex ? prev + 1 : prev))
+      if (e.key === 'Tab') {
+        if (isEndIndex) {
+          closeResult()
+        } else {
+          e.preventDefault()
+        }
+      }
+    }
+    if (!isResultOpen && e.key === 'ArrowDown') {
+      setSelectIndex(0)
+      openResult()
+    }
+  }
+
+  const closeAndReset = () => {
+    closeResult()
+    setSelectIndex(-1)
+  }
+
+  const selectCurrent = () => {
+    setSelectedItem(resultArray[selectIndex])
+  }
+
+  const navigateFocus = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowUp' || (e.shiftKey && e.key === 'Tab')) {
+      moveToPrev(e)
+    } else if (e.key === 'ArrowDown' || e.key === 'Tab') {
+      moveToNext(e)
+    } else if (e.key === 'Escape') {
+      closeAndReset()
+    } else if (e.key === 'Enter') {
+      selectCurrent()
+    }
+  }
+
+  useEffect(() => {
+    openResult()
+    setSelectIndex(-1)
+  }, [resultArray])
+
+  return { selectIndex, navigateFocus, selectedItem }
+}
+
+export default useKeyboardNavigation

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,16 +1,87 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import SearchForm from '../components/search/SearchForm'
 import SearchSuggestion from '../components/search/SearchSuggestion'
+import useDebounce from '../hooks/useDebounce'
+import useSuggestions from '../hooks/useSuggestions'
+
+const DEBOUNCE_DELAY = 500
 
 export default function MainPage() {
   const [keyword, setKeyword] = useState<string>('')
+  const [isSuggestionOpen, setIsSuggestionOpen] = useState(false)
+  const [selectIndex, setSelectIndex] = useState(-1)
+  const searchRef = useRef<HTMLDivElement>(null)
+  const debouncedValue = useDebounce(keyword, DEBOUNCE_DELAY)
+  const { suggestions, loading, error } = useSuggestions(debouncedValue)
+
   const getInput = (value: string): void => {
     setKeyword(value)
   }
 
+  const openSuggestion = () => {
+    setIsSuggestionOpen(true)
+  }
+
+  const closeSuggestion = () => {
+    setIsSuggestionOpen(false)
+  }
+
+  const navigateFocus = (e: React.KeyboardEvent) => {
+    const startIndex = 0
+    const endIndex = suggestions.length - 1
+
+    if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey)) {
+      e.preventDefault()
+      if (selectIndex === startIndex) {
+        closeSuggestion()
+      } else {
+        setSelectIndex((prev) => prev - 1)
+      }
+    } else if (e.key === 'ArrowDown' || e.key === 'Tab') {
+      if (e.key === 'ArrowDown') {
+        if (isSuggestionOpen) {
+          setSelectIndex((prev) => (prev < endIndex ? prev + 1 : prev))
+        } else {
+          setSelectIndex(0)
+          openSuggestion()
+        }
+      } else if (e.key === 'Tab') {
+        if (isSuggestionOpen) {
+          setSelectIndex((prev) => (prev < endIndex ? prev + 1 : prev))
+          if (selectIndex !== endIndex) {
+            e.preventDefault()
+          } else {
+            closeSuggestion()
+          }
+        }
+      }
+    } else if (e.key === 'Escape') {
+      closeSuggestion()
+    } else if (e.key === 'Enter') {
+      setKeyword(suggestions[selectIndex].sickNm)
+    }
+  }
+
+  useEffect(() => {
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
+        setIsSuggestionOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleOutsideClick)
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick)
+    }
+  }, [])
+
+  useEffect(() => {
+    openSuggestion()
+    setSelectIndex(-1)
+  }, [keyword])
+
   return (
-    <section>
+    <section ref={searchRef}>
       <h2>검색하기</h2>
       <p>
         국내 모든 임상시험 검색하고
@@ -18,8 +89,21 @@ export default function MainPage() {
         온라인으로 참여하기
       </p>
 
-      <SearchForm getInput={getInput} keyword={keyword} />
-      <SearchSuggestion keyword={keyword} />
+      <SearchForm
+        getInput={getInput}
+        keyword={keyword}
+        navigateFocus={navigateFocus}
+        openSuggestion={openSuggestion}
+      />
+      {isSuggestionOpen && (
+        <SearchSuggestion
+          error={error}
+          keyword={keyword}
+          loading={loading}
+          selectIndex={selectIndex}
+          suggestions={suggestions}
+        />
+      )}
     </section>
   )
 }

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import SearchForm from '../components/search/SearchForm'
 import SearchSuggestion from '../components/search/SearchSuggestion'
 import useDebounce from '../hooks/useDebounce'
+import useKeyboardNavigation from '../hooks/useKeyboardNavigation'
 import useSuggestions from '../hooks/useSuggestions'
 
 const DEBOUNCE_DELAY = 500
@@ -10,10 +11,14 @@ const DEBOUNCE_DELAY = 500
 export default function MainPage() {
   const [keyword, setKeyword] = useState<string>('')
   const [isSuggestionOpen, setIsSuggestionOpen] = useState(false)
-  const [selectIndex, setSelectIndex] = useState(-1)
   const searchRef = useRef<HTMLDivElement>(null)
   const debouncedValue = useDebounce(keyword, DEBOUNCE_DELAY)
   const { suggestions, loading, error } = useSuggestions(debouncedValue)
+  const { selectIndex, navigateFocus, selectedItem } = useKeyboardNavigation(
+    suggestions,
+    isSuggestionOpen,
+    setIsSuggestionOpen
+  )
 
   const getInput = (value: string): void => {
     setKeyword(value)
@@ -21,46 +26,6 @@ export default function MainPage() {
 
   const openSuggestion = () => {
     setIsSuggestionOpen(true)
-  }
-
-  const closeSuggestion = () => {
-    setIsSuggestionOpen(false)
-  }
-
-  const navigateFocus = (e: React.KeyboardEvent) => {
-    const startIndex = 0
-    const endIndex = suggestions.length - 1
-
-    if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey)) {
-      e.preventDefault()
-      if (selectIndex === startIndex) {
-        closeSuggestion()
-      } else {
-        setSelectIndex((prev) => prev - 1)
-      }
-    } else if (e.key === 'ArrowDown' || e.key === 'Tab') {
-      if (e.key === 'ArrowDown') {
-        if (isSuggestionOpen) {
-          setSelectIndex((prev) => (prev < endIndex ? prev + 1 : prev))
-        } else {
-          setSelectIndex(0)
-          openSuggestion()
-        }
-      } else if (e.key === 'Tab') {
-        if (isSuggestionOpen) {
-          setSelectIndex((prev) => (prev < endIndex ? prev + 1 : prev))
-          if (selectIndex !== endIndex) {
-            e.preventDefault()
-          } else {
-            closeSuggestion()
-          }
-        }
-      }
-    } else if (e.key === 'Escape') {
-      closeSuggestion()
-    } else if (e.key === 'Enter') {
-      setKeyword(suggestions[selectIndex].sickNm)
-    }
   }
 
   useEffect(() => {
@@ -76,9 +41,10 @@ export default function MainPage() {
   }, [])
 
   useEffect(() => {
-    openSuggestion()
-    setSelectIndex(-1)
-  }, [keyword])
+    if (selectedItem) {
+      setKeyword(selectedItem.sickNm)
+    }
+  }, [selectedItem])
 
   return (
     <section ref={searchRef}>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 
 import SearchForm from '../components/search/SearchForm'
 import SearchSuggestion from '../components/search/SearchSuggestion'
@@ -10,66 +10,39 @@ const DEBOUNCE_DELAY = 500
 
 export default function MainPage() {
   const [keyword, setKeyword] = useState<string>('')
-  const [isSuggestionOpen, setIsSuggestionOpen] = useState(false)
-  const searchRef = useRef<HTMLDivElement>(null)
   const debouncedValue = useDebounce(keyword, DEBOUNCE_DELAY)
   const { suggestions, loading, error } = useSuggestions(debouncedValue)
-  const { selectIndex, navigateFocus, selectedItem } = useKeyboardNavigation(
-    suggestions,
-    isSuggestionOpen,
-    setIsSuggestionOpen
-  )
+  const { currentIndex, changeIndexByKeyDown } = useKeyboardNavigation(suggestions)
+  const isOpen = currentIndex > -1
 
   const getInput = (value: string): void => {
     setKeyword(value)
   }
 
-  const openSuggestion = () => {
-    setIsSuggestionOpen(true)
-  }
-
-  useEffect(() => {
-    const handleOutsideClick = (e: MouseEvent) => {
-      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
-        setIsSuggestionOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleOutsideClick)
-    return () => {
-      document.removeEventListener('mousedown', handleOutsideClick)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (selectedItem) {
-      setKeyword(selectedItem.sickNm)
-    }
-  }, [selectedItem])
-
   return (
-    <section ref={searchRef}>
+    <section>
       <h2>검색하기</h2>
       <p>
         국내 모든 임상시험 검색하고
         <br />
         온라인으로 참여하기
       </p>
-
-      <SearchForm
-        getInput={getInput}
-        keyword={keyword}
-        navigateFocus={navigateFocus}
-        openSuggestion={openSuggestion}
-      />
-      {isSuggestionOpen && (
-        <SearchSuggestion
-          error={error}
+      <div onKeyDown={changeIndexByKeyDown}>
+        <SearchForm
+          changeIndexByKeyDown={changeIndexByKeyDown}
+          getInput={getInput}
           keyword={keyword}
-          loading={loading}
-          selectIndex={selectIndex}
-          suggestions={suggestions}
         />
-      )}
+        {isOpen && (
+          <SearchSuggestion
+            error={error}
+            keyword={keyword}
+            loading={loading}
+            selectIndex={currentIndex}
+            suggestions={suggestions}
+          />
+        )}
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Description

키보드로 추천 검색어 결과 이동 구현했습니다.

## Changes

- 포커스를 직접 이동하면 동시에 키워드 입력을 할 수 없게 되어 UX측면에서 좋지 않다고 생각했습니다. index 상태를 만들어 포커스가 이동한 것 처럼 보이게 구현했습니다.
- `suggestions`가 해당 기능 구현에 필요해 `SearchForm`에 있던 훅을 `MainPage`로 옮겼습니다.
- 조작 설명 (초록색: focus된 요소, 빨간색: 선택 요소)
  - 위 방향키 `↑`, `Shift + Tab`: 목록의 이전(위) 요소로 선택 이동, 목록의 첫 번째 요소에서 누를 시 목록 닫음
![prev](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-3-7/assets/97281800/1a4fdc01-25bc-4fe1-a806-d1efa6fa619f)
  - 아래 방향키 `↓`: 목록의 다음(아래) 요소로 선택 이동, 목록의 마지막 요소에서 누를 시 동작 X
  - `Tab`: 목록의 다음(아래) 요소로 선택 이동, 목록의 마지막 요소에서 누를 시 목록을 빠져나와 DOM 구조상 다음 요소 `focus`
![next](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-3-7/assets/97281800/c4b0244d-c3ab-497d-b4cf-1b78dc6935ab)
  - `esc`: 목록 닫기
![esc](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-3-7/assets/97281800/e6b9fca9-3c02-4775-bbae-0fff829d8d22)