### PR TITLE
fix: #19 macOS에서 onKeyDown이 2번 발생하는 문제 해결

### DIFF
--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -27,12 +27,14 @@ const useKeyboardNavigation = <T>(dataArr: T[]) => {
   }
 
   const changeIndexByKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowUp' || (e.shiftKey && e.key === 'Tab')) {
-      moveToPrev(e)
-    } else if (e.key === 'ArrowDown' || e.key === 'Tab') {
-      moveToNext(e)
-    } else if (e.key === 'Escape') {
-      closeAndReset()
+    if (!e.nativeEvent.isComposing) {
+      if (e.key === 'ArrowUp' || (e.shiftKey && e.key === 'Tab')) {
+        moveToPrev(e)
+      } else if (e.key === 'ArrowDown' || e.key === 'Tab') {
+        moveToNext(e)
+      } else if (e.key === 'Escape') {
+        closeAndReset()
+      }
     }
   }
 


### PR DESCRIPTION
## Description

#19 참조

## Changes

onKeyDown 이벤트 처리전 [isComposing](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing) 이벤트를 검사하여 한글 조합이 끝났을때만 해당 로직을 수행하도록 변경하였습니다.

```js
if (!e.nativeEvent.isComposing) {
  // 키보드 네비게이션 로직
}
```